### PR TITLE
Update CI to run on main, make CI action name clearer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: CI
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: On Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
         ruby:
@@ -25,5 +25,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Run the default task
+    - name: Run the CI task, which runs tests, rubocop and builds the gem
       run: bundle exec rake ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - CI: trigger on pushes to `main` instead of `stable` ([#5](https://github.com/q-m/questionmark-barcodes/issues/5))
+- CI: slightly changed name of task to indicate it's a CI task
 
 ## [0.1.0] - 2022-10-07
 


### PR DESCRIPTION
This resolves #5.

- CI: trigger on pushes to `main` instead of `stable` (8945f5d)
- CI: slightly changed name of task to indicate it's a CI task (7a5c469)
