### PR TITLE
Version 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.1.1] - 2022-11-11
+
+The first _public_ release. Functionally unchanged from 0.1.0, but the documentation is friendlier.
+
 - CI: trigger on pushes to `main` instead of `stable` ([#5](https://github.com/q-m/questionmark-barcodes/issues/5))
 - CI: slightly changed name of task to indicate it's a CI task
 - Doc: update descriptions to be more helpful for outside perspectives ([#7](https://github.com/q-m/questionmark-barcodes/issues/7))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    questionmark-barcodes (0.1.0)
+    questionmark-barcodes (0.1.1)
       barcodevalidation (~> 2.6.0)
 
 GEM
@@ -71,4 +71,4 @@ DEPENDENCIES
   rubocop-thread_safety (~> 0.4.4)
 
 BUNDLED WITH
-   2.3.23
+   2.3.25

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We've got some documentation on how we use [barcodes](./doc/barcodes.md) and [du
 
 Because this won't be published as a gem on Github, you can install it by adding this to the application's `Gemfile`:
 
-    gem 'questionmark-barcodes', github: 'q-m/questionmark-barcodes', tag: 'v0.1.0'
+    gem 'questionmark-barcodes', github: 'q-m/questionmark-barcodes', tag: 'v0.1.1'
 
 This pins the gem to a specific release, allowing us to continue updating the repository and create new releases periodically that projects can adopt at their own pace.
 
@@ -46,7 +46,8 @@ This project intends to follow [Semantic Versioning](https://semver.org/). This 
 
 - Check the [Changelog](./CHANGELOG.md) and ensure you've added a header for the new version + date that captures all unreleased changes.
 - Update [version.rb](./lib/questionmark/barcodes/version.rb) to match this new version
-- Run `bundle exec rake release` to create a commit + tag based on this, and push them to GitHub. We automatically set the ENV variable `gem_push=no` in our [Rakefile](./Rakefile) to ensure we don't push the gem to rubygems.org.
+- Create a local new branch "version-X-Y-Z" and commit the changes `git commit -am "Version X.Y.Z"`
+- Run `bundle exec rake release` to create a tag based on this, and it and the commit them to GitHub. We automatically set the ENV variable `gem_push=no` in our [Rakefile](./Rakefile) to ensure we don't push the gem to rubygems.org.
 
 ## Contributing
 

--- a/lib/questionmark/barcodes/version.rb
+++ b/lib/questionmark/barcodes/version.rb
@@ -2,6 +2,6 @@
 
 module Questionmark
   module Barcodes
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
Our main branch is protected (useful feature!) but that means I need to create a PR to bump the version.

The commit in this PR (d4b3f4fd5c444089c0b4aadbabdb0c2c29f3ae37) is tagged with `v0.1.1` so please _don't_ use a squash merge for this because that breaks the tag. Use a regular merge instead.

This resolves #4.